### PR TITLE
Install guide and generic user names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *~
 *pyc
 Makefile
+*.log
+

--- a/README.md
+++ b/README.md
@@ -13,16 +13,29 @@ Allows computers from different IPs to issue HTTP request.
 
 ``` shell
 # install uwsgi
-pip install uwsgi
+$ pip install uwsgi
 
 # install mysqlclient
-sudo apt-get install python-dev libmysqlclient-dev # Debian / Ubuntu
-sudo apt-get install python3-dev # debian / Ubuntu
-pip install mysqlclient
+$ sudo apt-get install python-dev libmysqlclient-dev # Debian / Ubuntu
+$ sudo apt-get install python3-dev # debian / Ubuntu
+$ pip install mysqlclient
+
+# install mysql.connector python. 
+# See https://dev.mysql.com/doc/connector-python/en/connector-python-installation.html
+# download mysql-connector here: http://dev.mysql.com/downloads/connector/python/
+$ dpkg -i mysql-connector-python_2.1.3-1ubuntu15.04_all.deb
+
 
 # install Django
-pip install Django
+$ pip install Django
 
 ```
 
 ### mysql settings
+``` SQL
+$ mysql -u root -p
+> CREATE DATABASE wolfie_home;
+> CREATE USER 'wolfie'@'localhost' IDENTIFIED BY 'dummypass';
+> GRANT ALL PRIVILEGES ON wolfie_home.* TO 'wolfie'@'localhost';
+```
+Then create tables. [See here.](https://github.com/Wolfie-Home/Documents/blob/bumsik/Design%20Document/Design_Document.md#51-mysql)

--- a/README.md
+++ b/README.md
@@ -7,3 +7,22 @@ Allows computers from different IPs to issue HTTP request.
 ```
 ./run
 ```
+
+
+### install dependancies
+
+``` shell
+# install uwsgi
+pip install uwsgi
+
+# install mysqlclient
+sudo apt-get install python-dev libmysqlclient-dev # Debian / Ubuntu
+sudo apt-get install python3-dev # debian / Ubuntu
+pip install mysqlclient
+
+# install Django
+pip install Django
+
+```
+
+### mysql settings

--- a/wolfie_home/settings.py
+++ b/wolfie_home/settings.py
@@ -78,7 +78,7 @@ DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.mysql',
         'NAME': 'wolfie_home',
-        'USER': 'chaojie',
+        'USER': 'wolfie',
         'PASSWORD': 'dummypass',
         'HOST': 'localhost',
     }

--- a/wolfie_home/wolfie_db.py
+++ b/wolfie_home/wolfie_db.py
@@ -19,7 +19,7 @@ class WolfieDB():
         self.conn = None        # mysql connection
         if config == None:
             config = {
-                'user': 'chaojie',
+                'user': 'wolfie',
                 'password': 'dummypass',
                 'host': 'localhost',
                 'database': 'wolfie_home',


### PR DESCRIPTION
As you might easily see, there are two changes.
1. Install guide updated.
2. Change the DB user name to `wolfie`. Yest wolfie do IoT for us.

WARNING: You may have to add `wolfie` user for all privileges in the data at this moment. Just deleting `chaojie` will make `vclient` broken.
